### PR TITLE
feat: add folder selection on context menu download

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -266,5 +266,80 @@
   },
   "toggleCaptureDownloadsNoServer": {
     "message": "No server available to capture downloads."
+  },
+  "folderPickerTitle": {
+    "message": "Download to..."
+  },
+  "folderPickerSelectFolder": {
+    "message": "Select destination folder"
+  },
+  "folderPickerUseCustomPath": {
+    "message": "Use custom path"
+  },
+  "folderPickerCustomPath": {
+    "message": "Custom path"
+  },
+  "folderPickerCustomPathPlaceholder": {
+    "message": "/path/to/folder"
+  },
+  "folderPickerDownload": {
+    "message": "Download"
+  },
+  "folderPickerCancel": {
+    "message": "Cancel"
+  },
+  "folderPickerNoPresets": {
+    "message": "No folder presets configured"
+  },
+  "folderPickerNoFolderSelected": {
+    "message": "Please select a folder or enter a custom path"
+  },
+  "extensionOptionsAskForFolder": {
+    "message": "Ask for folder on download"
+  },
+  "extensionOptionsAskForFolderDescription": {
+    "message": "Show folder picker when downloading via context menu"
+  },
+  "extensionOptionsDefaultFolder": {
+    "message": "Default download folder"
+  },
+  "extensionOptionsDefaultFolderPlaceholder": {
+    "message": "/path/to/downloads"
+  },
+  "extensionOptionsDefaultFolderDescription": {
+    "message": "Leave empty to use server default. Used when folder picker is disabled."
+  },
+  "extensionOptionsFolderPresets": {
+    "message": "Folder Presets"
+  },
+  "extensionOptionsFolderPresetsDescription": {
+    "message": "Quick access folders for the download picker"
+  },
+  "folderPresetName": {
+    "message": "Name"
+  },
+  "folderPresetPath": {
+    "message": "Path"
+  },
+  "folderPresetNamePlaceholder": {
+    "message": "Preset name"
+  },
+  "folderPresetPathPlaceholder": {
+    "message": "/path/to/folder"
+  },
+  "folderPresetAdd": {
+    "message": "Add"
+  },
+  "folderPickerNoPresetsHint": {
+    "message": "No folder presets configured. Enter a custom path below or"
+  },
+  "folderPickerAddPresets": {
+    "message": "add presets in Options"
+  },
+  "folderPickerDownloadNormally": {
+    "message": "Browser"
+  },
+  "folderPickerDownloadNormallyHint": {
+    "message": "Download using browser's default downloader instead of Aria2"
   }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -266,5 +266,80 @@
   },
   "toggleCaptureDownloadsNoServer": {
     "message": "Aucun serveur disponible pour capturer les téléchargements."
+  },
+  "folderPickerTitle": {
+    "message": "Télécharger vers..."
+  },
+  "folderPickerSelectFolder": {
+    "message": "Sélectionner le dossier de destination"
+  },
+  "folderPickerUseCustomPath": {
+    "message": "Utiliser un chemin personnalisé"
+  },
+  "folderPickerCustomPath": {
+    "message": "Chemin personnalisé"
+  },
+  "folderPickerCustomPathPlaceholder": {
+    "message": "/chemin/vers/dossier"
+  },
+  "folderPickerDownload": {
+    "message": "Télécharger"
+  },
+  "folderPickerCancel": {
+    "message": "Annuler"
+  },
+  "folderPickerNoPresets": {
+    "message": "Aucun dossier prédéfini configuré"
+  },
+  "folderPickerNoFolderSelected": {
+    "message": "Veuillez sélectionner un dossier ou entrer un chemin personnalisé"
+  },
+  "extensionOptionsAskForFolder": {
+    "message": "Demander le dossier lors du téléchargement"
+  },
+  "extensionOptionsAskForFolderDescription": {
+    "message": "Afficher le sélecteur de dossier lors du téléchargement via le menu contextuel"
+  },
+  "extensionOptionsDefaultFolder": {
+    "message": "Dossier de téléchargement par défaut"
+  },
+  "extensionOptionsDefaultFolderPlaceholder": {
+    "message": "/chemin/vers/téléchargements"
+  },
+  "extensionOptionsDefaultFolderDescription": {
+    "message": "Laissez vide pour utiliser le dossier par défaut du serveur. Utilisé lorsque le sélecteur de dossier est désactivé."
+  },
+  "extensionOptionsFolderPresets": {
+    "message": "Dossiers prédéfinis"
+  },
+  "extensionOptionsFolderPresetsDescription": {
+    "message": "Dossiers d'accès rapide pour le sélecteur de téléchargement"
+  },
+  "folderPresetName": {
+    "message": "Nom"
+  },
+  "folderPresetPath": {
+    "message": "Chemin"
+  },
+  "folderPresetNamePlaceholder": {
+    "message": "Nom du préréglage"
+  },
+  "folderPresetPathPlaceholder": {
+    "message": "/chemin/vers/dossier"
+  },
+  "folderPresetAdd": {
+    "message": "Ajouter"
+  },
+  "folderPickerNoPresetsHint": {
+    "message": "Aucun dossier prédéfini. Entrez un chemin personnalisé ci-dessous ou"
+  },
+  "folderPickerAddPresets": {
+    "message": "ajoutez des préréglages dans les Options"
+  },
+  "folderPickerDownloadNormally": {
+    "message": "Navigateur"
+  },
+  "folderPickerDownloadNormallyHint": {
+    "message": "Télécharger avec le gestionnaire par défaut du navigateur au lieu d'Aria2"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -266,5 +266,80 @@
   },
   "toggleCaptureDownloadsNoServer": {
     "message": "没有可用的服务器来拦截下载."
+  },
+  "folderPickerTitle": {
+    "message": "下载到..."
+  },
+  "folderPickerSelectFolder": {
+    "message": "选择目标文件夹"
+  },
+  "folderPickerUseCustomPath": {
+    "message": "使用自定义路径"
+  },
+  "folderPickerCustomPath": {
+    "message": "自定义路径"
+  },
+  "folderPickerCustomPathPlaceholder": {
+    "message": "/路径/到/文件夹"
+  },
+  "folderPickerDownload": {
+    "message": "下载"
+  },
+  "folderPickerCancel": {
+    "message": "取消"
+  },
+  "folderPickerNoPresets": {
+    "message": "未配置文件夹预设"
+  },
+  "folderPickerNoFolderSelected": {
+    "message": "请选择文件夹或输入自定义路径"
+  },
+  "extensionOptionsAskForFolder": {
+    "message": "下载时询问文件夹"
+  },
+  "extensionOptionsAskForFolderDescription": {
+    "message": "通过右键菜单下载时显示文件夹选择器"
+  },
+  "extensionOptionsDefaultFolder": {
+    "message": "默认下载文件夹"
+  },
+  "extensionOptionsDefaultFolderPlaceholder": {
+    "message": "/路径/到/下载"
+  },
+  "extensionOptionsDefaultFolderDescription": {
+    "message": "留空则使用服务器默认值。当文件夹选择器禁用时使用。"
+  },
+  "extensionOptionsFolderPresets": {
+    "message": "文件夹预设"
+  },
+  "extensionOptionsFolderPresetsDescription": {
+    "message": "下载选择器的快速访问文件夹"
+  },
+  "folderPresetName": {
+    "message": "名称"
+  },
+  "folderPresetPath": {
+    "message": "路径"
+  },
+  "folderPresetNamePlaceholder": {
+    "message": "预设名称"
+  },
+  "folderPresetPathPlaceholder": {
+    "message": "/路径/到/文件夹"
+  },
+  "folderPresetAdd": {
+    "message": "添加"
+  },
+  "folderPickerNoPresetsHint": {
+    "message": "未配置文件夹预设。请在下方输入自定义路径，或"
+  },
+  "folderPickerAddPresets": {
+    "message": "在选项中添加预设"
+  },
+  "folderPickerDownloadNormally": {
+    "message": "浏览器"
+  },
+  "folderPickerDownloadNormallyHint": {
+    "message": "使用浏览器默认下载器代替 Aria2"
   }
 }

--- a/src/folder-picker/folder-picker.css
+++ b/src/folder-picker/folder-picker.css
@@ -1,0 +1,30 @@
+.folder-picker-container {
+  min-width: 400px;
+}
+
+.folder-picker-header {
+  margin-bottom: 1rem;
+}
+
+.folder-picker-url {
+  font-size: 0.85rem;
+  color: var(--bs-secondary);
+  word-break: break-all;
+  max-height: 3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.folder-picker-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--bs-border-color);
+}
+
+.folder-picker-actions-right {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/src/folder-picker/folder-picker.html
+++ b/src/folder-picker/folder-picker.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Folder Picker</title>
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="folder-picker.tsx"></script>
+</body>
+</html>

--- a/src/folder-picker/folder-picker.tsx
+++ b/src/folder-picker/folder-picker.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "bootstrap-icons/font/bootstrap-icons.css";
+import "bootstrap/dist/css/bootstrap.css";
+import "bootstrap";
+import "./folder-picker.css";
+import { Alert, Button, Container, Form } from "react-bootstrap";
+import browser from "webextension-polyfill";
+import i18n from "@/i18n";
+import ExtensionOptions from "@/models/extension-options";
+import type FolderPreset from "@/models/folder-preset";
+import { applyTheme } from "@/models/theme";
+
+interface PendingDownload {
+  serverId: string;
+  urls: string[];
+  referer: string;
+  cookies: string;
+}
+
+const container = document.getElementById("root");
+// biome-ignore lint/style/noNonNullAssertion: We are sure the container exists
+const root = createRoot(container!);
+
+function FolderPicker() {
+  const [extensionOptions, setExtensionOptions] = useState<ExtensionOptions>(new ExtensionOptions());
+  const [pendingDownload, setPendingDownload] = useState<PendingDownload | null>(null);
+  const [selectedPresetId, setSelectedPresetId] = useState<string>("");
+  const [customPath, setCustomPath] = useState<string>("");
+  const [useCustomPath, setUseCustomPath] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+
+  const hasPresets = extensionOptions.folderPresets.length > 0;
+
+  useEffect(() => {
+    const loadData = async () => {
+      const options = await ExtensionOptions.fromStorage();
+      setExtensionOptions(options);
+      applyTheme(options.theme);
+
+      // If no presets, auto-enable custom path mode
+      if (options.folderPresets.length === 0) {
+        setUseCustomPath(true);
+        // Pre-fill with default folder if set
+        if (options.defaultFolder) {
+          setCustomPath(options.defaultFolder);
+        }
+      } else {
+        // Set default selection to first preset
+        setSelectedPresetId(options.folderPresets[0].id);
+      }
+
+      // Get pending download info
+      const storage = await browser.storage.local.get("pendingDownload");
+      if (storage.pendingDownload) {
+        setPendingDownload(storage.pendingDownload as PendingDownload);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  const getSelectedFolder = (): string => {
+    if (useCustomPath) {
+      return customPath.trim();
+    }
+    const preset = extensionOptions.folderPresets.find((p: FolderPreset) => p.id === selectedPresetId);
+    return preset?.path ?? "";
+  };
+
+  const handleDownload = async () => {
+    const folder = getSelectedFolder();
+    if (!folder) {
+      setError(i18n("folderPickerNoFolderSelected"));
+      return;
+    }
+
+    await browser.runtime.sendMessage({
+      type: "folderPickerResponse",
+      folder,
+      cancelled: false,
+    });
+
+    window.close();
+  };
+
+  const handleCancel = async () => {
+    await browser.runtime.sendMessage({
+      type: "folderPickerResponse",
+      cancelled: true,
+    });
+
+    window.close();
+  };
+
+  const handleDownloadNormally = async () => {
+    // Clear pending download so aria2 doesn't get it
+    await browser.storage.local.remove("pendingDownload");
+
+    // Trigger browser's native download for each URL
+    if (pendingDownload?.urls) {
+      for (const url of pendingDownload.urls) {
+        browser.downloads.download({ url });
+      }
+    }
+
+    window.close();
+  };
+
+  const openOptions = () => {
+    browser.runtime.openOptionsPage();
+    window.close();
+  };
+
+  const displayUrl = pendingDownload?.urls?.[0] ?? "";
+  const urlCount = pendingDownload?.urls?.length ?? 0;
+
+  return (
+    <Container className="p-3 folder-picker-container" fluid>
+      <div className="folder-picker-header">
+        <h5>{i18n("folderPickerTitle")}</h5>
+        {displayUrl && <div className="folder-picker-url">{urlCount > 1 ? `${urlCount} URLs` : displayUrl}</div>}
+      </div>
+
+      {error && (
+        <Alert variant="danger" onClose={() => setError("")} dismissible>
+          {error}
+        </Alert>
+      )}
+
+      {!hasPresets && (
+        <Alert variant="info" className="py-2">
+          <small>
+            {i18n("folderPickerNoPresetsHint")}{" "}
+            <Alert.Link onClick={openOptions} style={{ cursor: "pointer" }}>
+              {i18n("folderPickerAddPresets")}
+            </Alert.Link>
+          </small>
+        </Alert>
+      )}
+
+      <Form>
+        {hasPresets && (
+          <>
+            <Form.Group className="mb-3">
+              <Form.Label>{i18n("folderPickerSelectFolder")}</Form.Label>
+              <Form.Select
+                value={selectedPresetId}
+                onChange={(e) => {
+                  setSelectedPresetId(e.target.value);
+                  setUseCustomPath(false);
+                }}
+                disabled={useCustomPath}
+              >
+                {extensionOptions.folderPresets.map((preset: FolderPreset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name} ({preset.path})
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Check
+                type="checkbox"
+                label={i18n("folderPickerUseCustomPath")}
+                checked={useCustomPath}
+                onChange={(e) => setUseCustomPath(e.target.checked)}
+              />
+            </Form.Group>
+          </>
+        )}
+
+        {useCustomPath && (
+          <Form.Group className="mb-3">
+            <Form.Label>{i18n("folderPickerCustomPath")}</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder={i18n("folderPickerCustomPathPlaceholder")}
+              value={customPath}
+              onChange={(e) => setCustomPath(e.target.value)}
+              autoFocus={!hasPresets}
+            />
+          </Form.Group>
+        )}
+
+        <div className="folder-picker-actions">
+          <Button variant="secondary" onClick={handleDownloadNormally} title={i18n("folderPickerDownloadNormallyHint")}>
+            <i className="bi bi-box-arrow-down me-1" />
+            {i18n("folderPickerDownloadNormally")}
+          </Button>
+          <div className="folder-picker-actions-right">
+            <Button variant="secondary" onClick={handleCancel}>
+              {i18n("folderPickerCancel")}
+            </Button>
+            <Button variant="primary" onClick={handleDownload}>
+              <i className="bi bi-download me-1" />
+              {i18n("folderPickerDownload")}
+            </Button>
+          </div>
+        </div>
+      </Form>
+    </Container>
+  );
+}
+
+root.render(
+  <React.StrictMode>
+    <FolderPicker />
+  </React.StrictMode>,
+);

--- a/src/models/extension-options.ts
+++ b/src/models/extension-options.ts
@@ -1,4 +1,5 @@
 import browser from "webextension-polyfill";
+import type FolderPreset from "@/models/folder-preset";
 import type Server from "@/models/server";
 import Theme from "@/models/theme";
 
@@ -16,6 +17,9 @@ export default class ExtensionOptions {
     public readonly notifyFileIsAdded: boolean = true,
     public readonly notifyErrorOccurs: boolean = true,
     public readonly theme: Theme = Theme.Auto,
+    public readonly folderPresets: FolderPreset[] = [],
+    public readonly askForFolderOnDownload: boolean = false,
+    public readonly defaultFolder: string = "",
   ) {}
 
   public serialize(): string {
@@ -46,6 +50,30 @@ export default class ExtensionOptions {
   async deleteServer(server: Server): Promise<ExtensionOptions> {
     const newExtensionOptions = this.copy();
     delete newExtensionOptions.servers[server.uuid];
+    return newExtensionOptions.toStorage();
+  }
+
+  async addFolderPreset(preset: FolderPreset): Promise<ExtensionOptions> {
+    const newExtensionOptions = this.copy();
+    (newExtensionOptions.folderPresets as FolderPreset[]).push(preset);
+    return newExtensionOptions.toStorage();
+  }
+
+  async updateFolderPreset(preset: FolderPreset): Promise<ExtensionOptions> {
+    const newExtensionOptions = this.copy();
+    const index = newExtensionOptions.folderPresets.findIndex((p) => p.id === preset.id);
+    if (index !== -1) {
+      (newExtensionOptions.folderPresets as FolderPreset[])[index] = preset;
+    }
+    return newExtensionOptions.toStorage();
+  }
+
+  async deleteFolderPreset(id: string): Promise<ExtensionOptions> {
+    const newExtensionOptions = this.copy();
+    const index = newExtensionOptions.folderPresets.findIndex((p) => p.id === id);
+    if (index !== -1) {
+      (newExtensionOptions.folderPresets as FolderPreset[]).splice(index, 1);
+    }
     return newExtensionOptions.toStorage();
   }
 

--- a/src/models/folder-preset.ts
+++ b/src/models/folder-preset.ts
@@ -1,0 +1,17 @@
+import { v4 as uuidv4 } from "uuid";
+
+export default class FolderPreset {
+  constructor(
+    public readonly id: string = uuidv4(),
+    public readonly name: string = "",
+    public readonly path: string = "",
+  ) {}
+
+  serialize(): string {
+    return JSON.stringify(this);
+  }
+
+  static deserialize(preset: string): FolderPreset {
+    return Object.assign(new FolderPreset(), JSON.parse(preset));
+  }
+}

--- a/src/options/components/extension-options-tab.tsx
+++ b/src/options/components/extension-options-tab.tsx
@@ -5,6 +5,7 @@ import { isChromium } from "@/aria2-extension";
 import i18n from "@/i18n";
 import ExtensionOptions from "@/models/extension-options";
 import Theme from "@/models/theme";
+import FolderPresetsEditor from "@/options/components/folder-presets-editor";
 import AlertProps from "@/options/models/alert-props";
 
 interface Props {
@@ -36,6 +37,8 @@ function ExtensionOptionsTab({ extensionOptions, setExtensionOptions }: Props) {
   const [notifyFileIsAdded, setNotifyFileIsAdded] = useState(extensionOptions.notifyFileIsAdded);
   const [notifyErrorOccurs, setNotifyErrorOccurs] = useState(extensionOptions.notifyErrorOccurs);
   const [theme, setTheme] = useState(extensionOptions.theme);
+  const [askForFolderOnDownload, setAskForFolderOnDownload] = useState(extensionOptions.askForFolderOnDownload);
+  const [defaultFolder, setDefaultFolder] = useState(extensionOptions.defaultFolder);
   const [alertProps, setAlertProps] = useState(new AlertProps());
   const [showModal, setShowModal] = useState(false);
   const [minFileSizeExponent, setMinFileSizeExponent] = useState(formatFileSize(extensionOptions.minFileSizeInBytes)[1]);
@@ -63,6 +66,8 @@ function ExtensionOptionsTab({ extensionOptions, setExtensionOptions }: Props) {
     setNotifyFileIsAdded(extensionOptions.notifyFileIsAdded);
     setNotifyErrorOccurs(extensionOptions.notifyErrorOccurs);
     setTheme(extensionOptions.theme);
+    setAskForFolderOnDownload(extensionOptions.askForFolderOnDownload);
+    setDefaultFolder(extensionOptions.defaultFolder);
   }, [
     extensionOptions.captureDownloads,
     extensionOptions.captureServer,
@@ -75,6 +80,8 @@ function ExtensionOptionsTab({ extensionOptions, setExtensionOptions }: Props) {
     extensionOptions.notifyFileIsAdded,
     extensionOptions.notifyErrorOccurs,
     extensionOptions.theme,
+    extensionOptions.askForFolderOnDownload,
+    extensionOptions.defaultFolder,
     formatFileSize,
     deserializeExcludedOption,
   ]);
@@ -115,6 +122,9 @@ function ExtensionOptionsTab({ extensionOptions, setExtensionOptions }: Props) {
         notifyFileIsAdded,
         notifyErrorOccurs,
         theme,
+        extensionOptions.folderPresets,
+        askForFolderOnDownload,
+        defaultFolder,
       ).toStorage();
       setExtensionOptions(newExtensionOptions);
       setAlertProps(AlertProps.success(i18n("serverOptionsSuccess")));
@@ -265,6 +275,37 @@ function ExtensionOptionsTab({ extensionOptions, setExtensionOptions }: Props) {
           </Button>
         </Modal.Footer>
       </Modal>
+
+      <Col xs={12} sm={12} className="mb-3">
+        <Form.Group controlId="form-ask-for-folder">
+          <Form.Check
+            checked={askForFolderOnDownload}
+            label={i18n("extensionOptionsAskForFolder")}
+            aria-label={i18n("extensionOptionsAskForFolder")}
+            onChange={(e) => setAskForFolderOnDownload(e.target.checked)}
+          />
+          <Form.Text className="text-muted">{i18n("extensionOptionsAskForFolderDescription")}</Form.Text>
+        </Form.Group>
+      </Col>
+
+      <Col xs={12} sm={12} className="mb-3">
+        <Form.Group controlId="form-default-folder">
+          <Form.Label>{i18n("extensionOptionsDefaultFolder")}</Form.Label>
+          <Form.Control
+            type="text"
+            placeholder={i18n("extensionOptionsDefaultFolderPlaceholder")}
+            value={defaultFolder}
+            onChange={(e) => setDefaultFolder(e.target.value)}
+          />
+          <Form.Text className="text-muted">{i18n("extensionOptionsDefaultFolderDescription")}</Form.Text>
+        </Form.Group>
+      </Col>
+
+      <Col xs={12} sm={12} className="mb-3">
+        <Form.Group controlId="form-folder-presets">
+          <FolderPresetsEditor extensionOptions={extensionOptions} setExtensionOptions={setExtensionOptions} />
+        </Form.Group>
+      </Col>
 
       <Col xs={12} sm={12} className="mb-3">
         <Form.Label>{i18n("extensionOptionsNotify")}</Form.Label>

--- a/src/options/components/folder-presets-editor.tsx
+++ b/src/options/components/folder-presets-editor.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { Button, Col, Form, InputGroup, ListGroup, Row } from "react-bootstrap";
+import i18n from "@/i18n";
+import type ExtensionOptions from "@/models/extension-options";
+import FolderPreset from "@/models/folder-preset";
+
+interface Props {
+  extensionOptions: ExtensionOptions;
+  setExtensionOptions: React.Dispatch<React.SetStateAction<ExtensionOptions>>;
+}
+
+function FolderPresetsEditor({ extensionOptions, setExtensionOptions }: Props) {
+  const [newPresetName, setNewPresetName] = useState("");
+  const [newPresetPath, setNewPresetPath] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editPath, setEditPath] = useState("");
+
+  const handleAddPreset = async () => {
+    if (!newPresetName.trim() || !newPresetPath.trim()) return;
+
+    const preset = new FolderPreset(undefined, newPresetName.trim(), newPresetPath.trim());
+    const newOptions = await extensionOptions.addFolderPreset(preset);
+    setExtensionOptions(newOptions);
+    setNewPresetName("");
+    setNewPresetPath("");
+  };
+
+  const handleDeletePreset = async (id: string) => {
+    const newOptions = await extensionOptions.deleteFolderPreset(id);
+    setExtensionOptions(newOptions);
+  };
+
+  const handleStartEdit = (preset: FolderPreset) => {
+    setEditingId(preset.id);
+    setEditName(preset.name);
+    setEditPath(preset.path);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditName("");
+    setEditPath("");
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim() || !editPath.trim()) return;
+
+    const updatedPreset = new FolderPreset(editingId, editName.trim(), editPath.trim());
+    const newOptions = await extensionOptions.updateFolderPreset(updatedPreset);
+    setExtensionOptions(newOptions);
+    handleCancelEdit();
+  };
+
+  return (
+    <>
+      <Form.Label>{i18n("extensionOptionsFolderPresets")}</Form.Label>
+      <Form.Text className="d-block mb-2 text-muted">{i18n("extensionOptionsFolderPresetsDescription")}</Form.Text>
+
+      {extensionOptions.folderPresets.length > 0 && (
+        <ListGroup className="mb-3">
+          {extensionOptions.folderPresets.map((preset) => (
+            <ListGroup.Item key={preset.id}>
+              {editingId === preset.id ? (
+                <Row className="g-2 align-items-center">
+                  <Col xs={12} md={4}>
+                    <Form.Control size="sm" type="text" placeholder={i18n("folderPresetName")} value={editName} onChange={(e) => setEditName(e.target.value)} />
+                  </Col>
+                  <Col xs={12} md={5}>
+                    <Form.Control size="sm" type="text" placeholder={i18n("folderPresetPath")} value={editPath} onChange={(e) => setEditPath(e.target.value)} />
+                  </Col>
+                  <Col xs={12} md={3} className="d-flex gap-1">
+                    <Button size="sm" variant="success" onClick={handleSaveEdit}>
+                      <i className="bi bi-check" />
+                    </Button>
+                    <Button size="sm" variant="secondary" onClick={handleCancelEdit}>
+                      <i className="bi bi-x" />
+                    </Button>
+                  </Col>
+                </Row>
+              ) : (
+                <Row className="align-items-center">
+                  <Col xs={12} md={4}>
+                    <strong>{preset.name}</strong>
+                  </Col>
+                  <Col xs={12} md={5}>
+                    <code className="text-muted">{preset.path}</code>
+                  </Col>
+                  <Col xs={12} md={3} className="d-flex gap-1 justify-content-end">
+                    <Button size="sm" variant="outline-primary" onClick={() => handleStartEdit(preset)}>
+                      <i className="bi bi-pencil" />
+                    </Button>
+                    <Button size="sm" variant="outline-danger" onClick={() => handleDeletePreset(preset.id)}>
+                      <i className="bi bi-trash" />
+                    </Button>
+                  </Col>
+                </Row>
+              )}
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+      )}
+
+      <InputGroup className="mb-2">
+        <Form.Control type="text" placeholder={i18n("folderPresetNamePlaceholder")} value={newPresetName} onChange={(e) => setNewPresetName(e.target.value)} />
+        <Form.Control type="text" placeholder={i18n("folderPresetPathPlaceholder")} value={newPresetPath} onChange={(e) => setNewPresetPath(e.target.value)} />
+        <Button variant="outline-primary" onClick={handleAddPreset} disabled={!newPresetName.trim() || !newPresetPath.trim()}>
+          <i className="bi bi-plus-lg me-1" />
+          {i18n("folderPresetAdd")}
+        </Button>
+      </InputGroup>
+    </>
+  );
+}
+
+export default FolderPresetsEditor;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         background: r("src", "background", "background.ts"),
         options: r("src", "options", "options.html"),
         popup: r("src", "popup", "popup.html"),
+        "folder-picker": r("src", "folder-picker", "folder-picker.html"),
       },
       output: {
         dir: r("dist"),


### PR DESCRIPTION
FYI: I really like this extension but for my flow these features was a bit of a deal breaker recently. rather than making my own, I tried to extend it. Would fully agree with any asks in regards of changing

- Add folder picker popup that appears when downloading via context menu
- Add folder presets management in extension options
- Add 'Ask for folder on download' toggle and 'Default folder' setting
- Add 'Download Normally' button to bypass aria2 and use browser downloader
- Add i18n support for en, fr, zh_CN locales
